### PR TITLE
Feat: Display collectible counters in HUD

### DIFF
--- a/Code/UI/CollectibleCounter.cs
+++ b/Code/UI/CollectibleCounter.cs
@@ -1,0 +1,60 @@
+// (c) 2026 Else Hell Entertainment
+// License: MIT License (see LICENSE in project root for details)
+// Author(s): Miska Rihu <miska.rihu@tuni.fi>
+
+using EHE.Common.Godot.Extensions;
+using Godot;
+
+namespace EHE.BoltBusters.Ui
+{
+    /// <summary>
+    ///  A counter that tracks one specific collectible defined by its
+    ///  <see cref="CollectibleType"/>.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///  This node is intended to be placed under the
+    ///  <see cref="CollectibleUi"/> node in the scene tree.
+    /// </remarks>
+    ///
+    /// <seealso cref="Collectible"/>
+    /// <seealso cref="ICollectible"/>
+    public partial class CollectibleCounter : BoxContainer
+    {
+        private TextureRect _iconRect;
+        private Label _valueLabel;
+
+        /// <summary>
+        ///  The type of collectible this counter keeps track of.
+        ///  The default value is <see cref="CollectibleType.None"/>.
+        /// </summary>
+        [Export]
+        public CollectibleType CollectibleType { get; private set; } = CollectibleType.None;
+
+        public override void _Ready()
+        {
+            _iconRect = this.GetFirstChildOfType<TextureRect>();
+            _valueLabel = this.GetFirstChildOfType<Label>();
+
+            if (_iconRect == null)
+            {
+                GD.PushError($"There is no valid node for {nameof(_iconRect)}!");
+            }
+
+            if (_valueLabel == null)
+            {
+                GD.PushError($"There is no valid node for {nameof(_valueLabel)}!");
+            }
+        }
+
+        /// <summary>
+        ///  Sets the display value for the counter.
+        /// </summary>
+        ///
+        /// <param name="value">The new value to display.</param>
+        public void SetCounterValue(int value)
+        {
+            _valueLabel.Text = $"{value}";
+        }
+    }
+}

--- a/Code/UI/CollectibleCounter.cs.uid
+++ b/Code/UI/CollectibleCounter.cs.uid
@@ -1,0 +1,1 @@
+uid://cox88j2hnu7m0

--- a/Code/UI/CollectibleUi.cs
+++ b/Code/UI/CollectibleUi.cs
@@ -1,0 +1,113 @@
+// (c) 2026 Else Hell Entertainment
+// License: MIT License (see LICENSE in project root for details)
+// Author(s): Miska Rihu <miska.rihu@tuni.fi>
+
+using System.Collections.Generic;
+using EHE.Common.Godot.Extensions;
+using Godot;
+
+namespace EHE.BoltBusters.Ui
+{
+    /// <summary>
+    ///  A container for collectible counters in the HUD.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///  This node is dependent on the <see cref="GameManager.CurrentPlayerData"/>
+    ///  in <see cref="GameManager"/>. The CollectibleUi node subscribes to the
+    ///  <see cref="PlayerData.CollectibleCountChanged"/> signal when it enters
+    ///  the scene tree. This signal is used to instruct the
+    ///  <see cref="CollectibleCounter"/> nodes under the CollectibleUi node to
+    ///  update their display values. If the signal cannot be connected, an
+    ///  error is logged.
+    /// </remarks>
+    ///
+    /// <seealso cref="ICollectible"/>
+    /// <seealso cref="Collectible"/>
+    /// <seealso cref="CollectibleCounter"/>
+    /// <seealso cref="PlayerData"/>
+    public partial class CollectibleUi : BoxContainer
+    {
+        // Internal mappings for collectible types and their counters.
+        private Godot.Collections.Dictionary<CollectibleType, CollectibleCounter> _collectibleCounters = new();
+
+        /// <summary>
+        ///  Connects the required signals. Logs an error if this fails.
+        /// </summary>
+        public override void _EnterTree()
+        {
+            if (GameManager.Instance == null || GameManager.Instance.CurrentPlayerData == null)
+            {
+                GD.PushError(
+                    $"Cannot connect signals. "
+                        + $"{nameof(GameManager.Instance)} or {nameof(GameManager.Instance.CurrentPlayerData)} is null!"
+                );
+                return;
+            }
+
+            GameManager.Instance.CurrentPlayerData.CollectibleCountChanged += SetCollectibleCount;
+        }
+
+        /// <summary>
+        ///  Disconnects the required signals.
+        /// </summary>
+        public override void _ExitTree()
+        {
+            if (GameManager.Instance != null && GameManager.Instance.CurrentPlayerData != null)
+            {
+                GameManager.Instance.CurrentPlayerData.CollectibleCountChanged -= SetCollectibleCount;
+            }
+        }
+
+        public override void _Ready()
+        {
+            CacheCounters();
+        }
+
+        /// <summary>
+        ///  Finds all counter nodes and creates mappings for them using their
+        ///  <see cref="CollectibleCounter.CollectibleType"/> as keys. If two or
+        ///  more counters with the same collectible type are found, the one
+        ///  that was found first is added to the mapping and a warning is
+        ///  logged for the rest of them.
+        /// </summary>
+        private void CacheCounters()
+        {
+            foreach (var counter in this.GetChildrenOfType<CollectibleCounter>(recurse: true))
+            {
+                if (!_collectibleCounters.TryAdd(counter.CollectibleType, counter))
+                {
+                    GD.PushWarning($"Cannot cache counter for type '{counter.CollectibleType}'. Already added?");
+                }
+            }
+
+            if (_collectibleCounters.Count == 0)
+            {
+                GD.PushWarning("No counters found in children. Is this intended?");
+            }
+        }
+
+        /// <summary>
+        ///  Sets the counter value for the given counter.
+        /// </summary>
+        ///
+        /// <param name="type">
+        ///  The type of the collectible whose counter should be set.
+        /// </param>
+        /// <param name="value">
+        ///  The new value shown in the counter.
+        /// </param>
+        private void SetCollectibleCount(int type, int value)
+        {
+            var collectibleType = (CollectibleType)type;
+
+            if (!_collectibleCounters.TryGetValue(collectibleType, out var counter))
+            {
+                GD.PushError($"Counter for '{collectibleType}' not found in {nameof(_collectibleCounters)}");
+                return;
+            }
+
+            counter.SetCounterValue(value);
+        }
+    }
+}

--- a/Code/UI/CollectibleUi.cs.uid
+++ b/Code/UI/CollectibleUi.cs.uid
@@ -1,0 +1,1 @@
+uid://ghaghpjeecs5

--- a/Scenes/UI/CollectibleCounter.tscn
+++ b/Scenes/UI/CollectibleCounter.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://c3on2c58of0pi"]
+
+[ext_resource type="Script" uid="uid://cox88j2hnu7m0" path="res://Code/UI/CollectibleCounter.cs" id="1_qy57m"]
+[ext_resource type="Texture2D" uid="uid://h5iw764dh18q" path="res://icon.svg" id="2_r634r"]
+
+[node name="CollectibleCounter" type="HBoxContainer" node_paths=PackedStringArray("_iconRect", "_valueLabel")]
+script = ExtResource("1_qy57m")
+_iconRect = NodePath("Icon")
+_valueLabel = NodePath("Value")
+
+[node name="Icon" type="TextureRect" parent="."]
+layout_mode = 2
+texture = ExtResource("2_r634r")
+expand_mode = 3
+stretch_mode = 4
+
+[node name="Value" type="Label" parent="."]
+layout_mode = 2
+text = "xxx"

--- a/Scenes/UI/HUD.tscn
+++ b/Scenes/UI/HUD.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://dibuxv5a07sr1"]
+[gd_scene load_steps=10 format=3 uid="uid://dibuxv5a07sr1"]
 
 [ext_resource type="Script" uid="uid://b0wwj8jxnwn6r" path="res://Code/UI/WeaponHud.cs" id="1_4bm6u"]
 [ext_resource type="Texture2D" uid="uid://h5iw764dh18q" path="res://icon.svg" id="1_omqfp"]
@@ -7,6 +7,8 @@
 [ext_resource type="Script" uid="uid://buhou76aa4uxs" path="res://Code/UI/WeaponUiChaingun.cs" id="5_ykvyr"]
 [ext_resource type="Script" uid="uid://sv650skqn02e" path="res://Code/UI/HealthUi.cs" id="6_lelo4"]
 [ext_resource type="Script" uid="uid://cmyu4wbi217m2" path="res://Code/UI/RoundTimerUi.cs" id="7_1ree7"]
+[ext_resource type="Script" uid="uid://ghaghpjeecs5" path="res://Code/UI/CollectibleUi.cs" id="9_pydgx"]
+[ext_resource type="PackedScene" uid="uid://c3on2c58of0pi" path="res://Scenes/UI/CollectibleCounter.tscn" id="10_yenib"]
 
 [node name="Hud" type="Control"]
 layout_mode = 3
@@ -486,3 +488,23 @@ text = "Time Remaining: "
 
 [node name="RoundTimeLabel" type="Label" parent="RoundTimerUi/HBoxContainer"]
 layout_mode = 2
+
+[node name="CollectibleUi" type="HBoxContainer" parent="."]
+layout_mode = 0
+offset_left = 947.0
+offset_top = 7.0
+offset_right = 1144.0
+offset_bottom = 39.0
+script = ExtResource("9_pydgx")
+
+[node name="NutCounter" parent="CollectibleUi" instance=ExtResource("10_yenib")]
+layout_mode = 2
+CollectibleType = 1
+
+[node name="BoltCounter" parent="CollectibleUi" instance=ExtResource("10_yenib")]
+layout_mode = 2
+CollectibleType = 2
+
+[node name="WrenchCounter" parent="CollectibleUi" instance=ExtResource("10_yenib")]
+layout_mode = 2
+CollectibleType = 3


### PR DESCRIPTION
- Create CollectibleCounter scene that shows the current number of collectibles based on CollectibleType.
- Create CollectibleUi node in HUD that is responsible for updating the counters under it when a signal is received.
- Add 3 counters to CollectibleUi, one for each collectible type.

Note: The counters do not initialize when the game is loaded from a save game. This will be addressed later.