### PR TITLE
Feat: Game over screen & Player death handling

### DIFF
--- a/Code/Level/LevelManager.cs
+++ b/Code/Level/LevelManager.cs
@@ -142,6 +142,12 @@ namespace EHE.BoltBusters
             _player = GetNodeOrNull<Player>("Player");
             _playerSpawnPosition = GetNodeOrNull<Node3D>("PlayerSpawnPosition");
 
+            // TODO: Replace this with a proper differentiation between bg level and regular level.
+            if (LevelType == LevelType.Background)
+            {
+                goto ValidationEnd;
+            }
+
             // TODO: Refactor validation code to a separate method.
             bool hasErrors = false;
 
@@ -174,6 +180,8 @@ namespace EHE.BoltBusters
                 GD.PushError($"Encountered problems when creating {Name} ({typeof(LevelManager)}).");
                 return;
             }
+
+            ValidationEnd:
 
             // Create object root nodes.
             _enemyRoot = new Node3D();

--- a/Code/Level/LevelManager.cs
+++ b/Code/Level/LevelManager.cs
@@ -114,6 +114,22 @@ namespace EHE.BoltBusters
 
         #region Overrides
 
+        /// <summary>
+        ///  Unsubscribes from the <see cref="Player.PlayerDied"/> event if
+        ///  applicable.
+        /// </summary>
+        public override void _ExitTree()
+        {
+            if (Player != null)
+            {
+                // This ensures that the signal is disconnected when the level
+                // manager exits the scene tree. The signal is also
+                // disconnected in the OnPlayerDeath method but this is only
+                // done if the player dies during the round.
+                Player.PlayerDied -= OnPlayerDeath;
+            }
+        }
+
         /// <inheritdoc/>
         public override void _Ready()
         {
@@ -233,6 +249,12 @@ namespace EHE.BoltBusters
             _roundTimer.WaitTime = _roundData.RoundLength;
             GameManager.Instance.SaveGame();
             this.PrintDebug("Initialized.");
+            Player.PlayerDied += OnPlayerDeath;
+
+            // Re-enable player input when a new round is loaded since it's
+            // disabled when the round ends or when the player dies.
+            Player.ToggleInputListening(true);
+
             EmitSignal(SignalName.Initialized);
         }
 
@@ -421,7 +443,7 @@ namespace EHE.BoltBusters
             _roundTimer.Stop();
             RoundInProgress = false;
             ResetLevel();
-            // TODO: Disable player movement.
+            Player.ToggleInputListening(false);
             // TODO: Disable enemy movement.
             GameManager.Instance.CurrentPlayerData.StartFromShop = true;
             GameManager.Instance.RoundIndex++;
@@ -457,6 +479,31 @@ namespace EHE.BoltBusters
                     spawnable.OnDespawn();
                 }
             }
+        }
+
+        /// <summary>
+        ///  Disables the player input, stops the round, and transitions to the
+        ///  game over state.
+        /// </summary>
+        ///
+        /// <param name="player">Reference to the player that died.</param>
+        ///
+        /// <remarks>
+        ///  When the player dies, the <see cref="LevelManager"/> unsibscribes
+        ///  from its <see cref="Player.PlayerDied"/> event to prevent this
+        ///  method from being triggered multiple times.
+        /// </remarks>
+        ///
+        /// <seealso cref="StateType"/>
+        /// <seealso cref="GameOverState"/>
+        private void OnPlayerDeath(Player player)
+        {
+            this.PrintDebug("Player died.");
+            Player.ToggleInputListening(false);
+            _roundTimer.Stop();
+            RoundInProgress = false;
+            GameManager.Instance.StateMachine.TransitionTo(StateType.GameOver);
+            Player.PlayerDied -= OnPlayerDeath;
         }
 
         #endregion Private Methods

--- a/Code/Objects/Player/Player.cs
+++ b/Code/Objects/Player/Player.cs
@@ -122,7 +122,8 @@ namespace EHE.BoltBusters
 
         public override void HandleDeath()
         {
-            OnDespawn();
+            EmitSignal(SignalName.PlayerDied, this);
+            // OnDespawn();
         }
 
         // Add additional logic if it differs from default (Node.QueueFree) method.

--- a/Code/Objects/Player/Player.cs
+++ b/Code/Objects/Player/Player.cs
@@ -6,6 +6,17 @@ namespace EHE.BoltBusters
 {
     public partial class Player : Character
     {
+        /// <summary>
+        ///  Emitted when the <see cref="HandleDeath"/> method of the
+        ///  <see cref="Player"/> is called.
+        /// </summary>
+        ///
+        /// <param name="player">
+        ///  Reference to the player object that died.
+        /// </param>
+        [Signal]
+        public delegate void PlayerDiedEventHandler(Player player);
+
         [Export]
         private EntityController _playerController;
         public PlayerChaingunController ChaingunController { get; private set; }

--- a/Code/Systems/GameManager.cs
+++ b/Code/Systems/GameManager.cs
@@ -464,7 +464,8 @@ namespace EHE.BoltBusters
                 new GameStateSettingsMenu(),
                 new GameStateRound(),
                 new GameStatePaused(),
-                new ShopState()
+                new ShopState(),
+                new GameOverState()
             );
         }
 

--- a/Code/Systems/GameStates/GameOverState.cs
+++ b/Code/Systems/GameStates/GameOverState.cs
@@ -1,0 +1,27 @@
+// (c) 2026 Else Hell Entertainment
+// License: MIT License (see LICENSE in project root for details)
+// Author(s): Rihu, Miska <email>
+
+using Godot;
+
+namespace EHE.BoltBusters.States
+{
+    public class GameOverState : GameState
+    {
+        /// <inheritdoc />
+        public override StateType StateType => StateType.GameOver;
+
+        /// <inheritdoc />
+        public override StringName ScenePath => "res://Scenes/UI/MenuGameOver.tscn";
+
+        /// <inheritdoc />
+        public override bool IsAdditive => true;
+
+        public GameOverState()
+        {
+            AddTargetState(StateType.MainMenu);
+            AddTargetState(StateType.SettingsMenu);
+            AddTargetState(StateType.Round);
+        }
+    }
+}

--- a/Code/Systems/GameStates/GameOverState.cs.uid
+++ b/Code/Systems/GameStates/GameOverState.cs.uid
@@ -1,0 +1,1 @@
+uid://crx5fa4khk8uc

--- a/Code/UI/MenuGameOver.cs
+++ b/Code/UI/MenuGameOver.cs
@@ -1,0 +1,60 @@
+// (c) 2026 Else Hell Entertainment
+// License: MIT License (see LICENSE in project root for details)
+// Author(s): Rihu, Miska <email>
+
+using EHE.BoltBusters.States;
+using Godot;
+
+namespace EHE.BoltBusters.Ui
+{
+    public partial class MenuGameOver : Menu
+    {
+        [Export]
+        private Button _btnRestart;
+
+        [Export]
+        private Button _btnSettings;
+
+        [Export]
+        private Button _btnMainMenu;
+
+        [Export]
+        private Button _btnQuit;
+
+        public override void _EnterTree()
+        {
+            _btnRestart.Pressed += OnBtnRestartPressed;
+            _btnSettings.Pressed += OnBtnSettingsPressed;
+            _btnMainMenu.Pressed += OnBtnMainMenuPressed;
+            _btnQuit.Pressed += OnBtnQuitPressed;
+        }
+
+        public override void _ExitTree()
+        {
+            _btnRestart.Pressed -= OnBtnRestartPressed;
+            _btnSettings.Pressed -= OnBtnSettingsPressed;
+            _btnMainMenu.Pressed -= OnBtnMainMenuPressed;
+            _btnQuit.Pressed -= OnBtnQuitPressed;
+        }
+
+        private void OnBtnRestartPressed()
+        {
+            GameManager.Instance.LoadGame();
+        }
+
+        private void OnBtnSettingsPressed()
+        {
+            GameManager.Instance.StateMachine.TransitionTo(StateType.SettingsMenu);
+        }
+
+        private void OnBtnMainMenuPressed()
+        {
+            GameManager.Instance.StateMachine.TransitionTo(StateType.MainMenu);
+        }
+
+        private void OnBtnQuitPressed()
+        {
+            GameManager.Instance.Quit();
+        }
+    }
+}

--- a/Code/UI/MenuGameOver.cs.uid
+++ b/Code/UI/MenuGameOver.cs.uid
@@ -1,0 +1,1 @@
+uid://c4orri7gxvo65

--- a/Scenes/UI/MenuGameOver.tscn
+++ b/Scenes/UI/MenuGameOver.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=0 format=3 uid="uid://dunxwyr0c7pq4"]
+[gd_scene load_steps=2 format=3 uid="uid://b8edrj8xvqqhb"]
 
-[node name="Control" type="PanelContainer"]
+[ext_resource type="Script" uid="uid://c4orri7gxvo65" path="res://Code/UI/MenuGameOver.cs" id="1_r2l5j"]
+
+[node name="Control" type="PanelContainer" node_paths=PackedStringArray("_btnRestart", "_btnSettings", "_btnMainMenu", "_btnQuit")]
 custom_minimum_size = Vector2(200, 200)
 anchors_preset = 8
 anchor_left = 0.5
@@ -13,6 +15,11 @@ offset_right = 100.0
 offset_bottom = 109.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_r2l5j")
+_btnRestart = NodePath("MarginContainer/VBoxContainer/RestartButton")
+_btnSettings = NodePath("MarginContainer/VBoxContainer/SettingsButton")
+_btnMainMenu = NodePath("MarginContainer/VBoxContainer/MainMenuButton")
+_btnQuit = NodePath("MarginContainer/VBoxContainer/QuitButton")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2

--- a/Scenes/UI/MenuGameOver.tscn
+++ b/Scenes/UI/MenuGameOver.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=0 format=3 uid="uid://dunxwyr0c7pq4"]
+
+[node name="Control" type="PanelContainer"]
+custom_minimum_size = Vector2(200, 200)
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 109.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="Header" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Game Over!"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="RestartButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Restart from Save"
+
+[node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="SettingsButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Settings"
+
+[node name="MainMenuButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Main Menu"
+
+[node name="QuitButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Quit"


### PR DESCRIPTION
- Create a class for the game over state.
- Create a menu scene for the game over state.
- Create and attach a controller script to the menu scene.
- Add `PlayerDied` signal to `Player`.
- Create `OnPlayerDeath` method in `LevelManager` and connect it to the `PlayerDied` signal emitted by the player.
- Modify `LevelManager` to enable/disable the player controls when applicable.
- Write a hack to get rid of the stupid error messages coming from the background level.

Part of #77.