### PR TITLE
Fix: Player input not disabled in shop after loading from save file

### DIFF
--- a/Code/Systems/GameStates/ShopState.cs
+++ b/Code/Systems/GameStates/ShopState.cs
@@ -17,5 +17,11 @@ namespace EHE.BoltBusters.States
             AddTargetState(StateType.Paused);
             AddTargetState(StateType.Round);
         }
+
+        protected override void OnEntered()
+        {
+            // TODO: There should probably be a better way to access the current player.
+            LevelManager.Active.Player?.ToggleInputListening(false);
+        }
     }
 }


### PR DESCRIPTION
Explicitly disable player input listening in the OnEntered method of the shop state.

Fixes: #195 