### PR TITLE
Fix: HUD elements shifting up when first rocket is bought

### DIFF
--- a/Scenes/UI/HUD.tscn
+++ b/Scenes/UI/HUD.tscn
@@ -167,6 +167,7 @@ layout_mode = 2
 texture = ExtResource("13_jt2rc")
 
 [node name="BottomUi" type="HBoxContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(24, 47)
 layout_mode = 2
 alignment = 1
 


### PR DESCRIPTION
Set minimum size for the bottom UI that matches the size of the rocket sprite.

Fixes: #196 