### PR TITLE
Fix: Secondary upgrade not unlocked in shop when weapon is purchased

### DIFF
--- a/Code/UI/Shop/UpgradeUi.cs
+++ b/Code/UI/Shop/UpgradeUi.cs
@@ -117,6 +117,7 @@ namespace EHE.BoltBusters.Ui
             if ((WeaponType)weaponType == _weaponType)
             {
                 _lblCurrentPrimaryCount.Text = $"{newValue}";
+                _btnSecondaryUpgrade.Disabled = newValue < 1;
             }
         }
 


### PR DESCRIPTION
Check the unlock condition for secondary upgrade when primary upgrade count is changed.