### PR TITLE
Fix: Railgun secondary upgrades not loaded properly when retry is selected after death

### DIFF
--- a/Code/Objects/Player/Weapons/PlayerWeaponGroupController.cs
+++ b/Code/Objects/Player/Weapons/PlayerWeaponGroupController.cs
@@ -154,6 +154,7 @@ namespace EHE.BoltBusters
                 AddWeapon();
             }
 
+            SecondaryUpgradeCount = 0; // Makes sure that the counter is reset before initialization.
             InitializeSecondaryUpgrades(secondaryCount);
 
             UpdatePlayerData();


### PR DESCRIPTION
Make sure the secondary upgrade count is reset when weapon controllers are initialized.